### PR TITLE
Bias UI

### DIFF
--- a/src/pages/Popup/components/Report/Bias/Bias.jsx
+++ b/src/pages/Popup/components/Report/Bias/Bias.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+import './Bias.scss';
+
+/**
+ * Constructs and returns the Bias JSX
+ * @param {String} bias the String bias returned from the MBFC
+ */
+const Bias = ({ bias }) => {
+
+  const [displayBias, setDisplayBias] = React.useState("DEFAULT_DISPLAY_BIAS");
+  const [isPoliticalBias, setIsPoliticalBias] = React.useState(true);
+
+  React.useEffect(() => {
+    if (bias === "least biased" || bias === "least") {
+      setDisplayBias("center");
+    } else if (bias === "conspiracy" || bias === "conspiracy/pseudoscience" || bias === "pro-science" || bias === "questionable") {
+      setIsPoliticalBias(false);
+    } else if (bias === "not parsed") {
+      setDisplayBias("No bias data");
+    } else {
+      setDisplayBias("ERROR: Invalid Bias");
+    }
+  }, []);
+
+  return (
+    <div className="bias-content">
+      <div className="bias-boxes">
+        <div className={`bias-box ${bias === "left" ? "left" : ""}`}>L</div>
+        <div className={`bias-box ${bias === "left-center" ? "left-center" : ""}`}>L-C</div>
+        <div className={`bias-box ${bias === "least" || bias === "least biased" ? "center" : ""}`}>C</div>
+        <div className={`bias-box ${bias === "right-center" ? "right-center" : ""}`}>R-C</div>
+        <div className={`bias-box ${bias === "right" ? "right" : ""}`}>R</div>
+      </div>
+      <article>This source generally has the following bias: {bias} </article>
+    </div>
+  )
+};
+
+Bias.propTypes = {
+  bias: PropTypes.string.isRequired,
+};
+
+export default Bias;

--- a/src/pages/Popup/components/Report/Bias/Bias.jsx
+++ b/src/pages/Popup/components/Report/Bias/Bias.jsx
@@ -11,13 +11,24 @@ const Bias = ({ bias }) => {
   const [displayBias, setDisplayBias] = React.useState("DEFAULT_DISPLAY_BIAS");
   const [isPoliticalBias, setIsPoliticalBias] = React.useState(true);
 
+  const NONPOLITICAL_COLOR_SCHEME = {
+    "conspiracy": "fake",
+    "conspiracy/pseudoscience": "fake",
+    "pro-science": "science",
+    "questionable": "questionable",
+    "fake": "fake",
+    "satire": "fake",
+  }
+
   React.useEffect(() => {
     if (bias === "least biased" || bias === "least") {
       setDisplayBias("center");
-    } else if (bias === "conspiracy" || bias === "conspiracy/pseudoscience" || bias === "pro-science" || bias === "questionable") {
+    } else if (bias === "conspiracy" || bias === "conspiracy/pseudoscience" || bias === "pro-science" || bias === "questionable" || bias === "fake" || bias === "satire") {
       setIsPoliticalBias(false);
     } else if (bias === "not parsed") {
       setDisplayBias("No bias data");
+    } else if (bias === "left" || bias === "left-center" || bias === "right-center" || bias === "right") {
+      setDisplayBias(bias);
     } else {
       setDisplayBias("ERROR: Invalid Bias");
     }
@@ -25,14 +36,22 @@ const Bias = ({ bias }) => {
 
   return (
     <div className="bias-content">
-      <div className="bias-boxes">
-        <div className={`bias-box ${bias === "left" ? "left" : ""}`}>L</div>
-        <div className={`bias-box ${bias === "left-center" ? "left-center" : ""}`}>L-C</div>
-        <div className={`bias-box ${bias === "least" || bias === "least biased" ? "center" : ""}`}>C</div>
-        <div className={`bias-box ${bias === "right-center" ? "right-center" : ""}`}>R-C</div>
-        <div className={`bias-box ${bias === "right" ? "right" : ""}`}>R</div>
-      </div>
-      <article>This source generally has the following bias: {bias} </article>
+      {isPoliticalBias ? (
+        <div>
+          <div className="bias-boxes">
+            <div className={`bias-box ${bias === "left" ? "left" : ""}`}>L</div>
+            <div className={`bias-box ${bias === "left-center" ? "left-center" : ""}`}>L-C</div>
+            <div className={`bias-box ${bias === "least" || bias === "least biased" ? "center" : ""}`}>C</div>
+            <div className={`bias-box ${bias === "right-center" ? "right-center" : ""}`}>R-C</div>
+            <div className={`bias-box ${bias === "right" ? "right" : ""}`}>R</div>
+          </div>
+          <article>This source generally has the following bias: {displayBias} </article>
+        </div>
+      ) : (
+          <div className={`nonpolitical-bias ${NONPOLITICAL_COLOR_SCHEME[bias]}`}>
+            {bias}
+          </div>
+        )}
     </div>
   )
 };

--- a/src/pages/Popup/components/Report/Bias/Bias.jsx
+++ b/src/pages/Popup/components/Report/Bias/Bias.jsx
@@ -13,7 +13,7 @@ const Bias = ({ bias }) => {
 
   const NONPOLITICAL_COLOR_SCHEME = {
     "conspiracy": "fake",
-    "conspiracy/pseudoscience": "fake",
+    "conspiracy/pseudoscience": "fake conspiracy-pseudo",
     "pro-science": "science",
     "questionable": "questionable",
     "fake": "fake",

--- a/src/pages/Popup/components/Report/Bias/Bias.jsx
+++ b/src/pages/Popup/components/Report/Bias/Bias.jsx
@@ -45,7 +45,7 @@ const Bias = ({ bias }) => {
             <div className={`bias-box ${bias === "right-center" ? "right-center" : ""}`}>R-C</div>
             <div className={`bias-box ${bias === "right" ? "right" : ""}`}>R</div>
           </div>
-          <article>This source generally has the following bias: {displayBias} </article>
+          <p>This source generally has the following bias: {displayBias} </p>
         </div>
       ) : (
           <div className={`nonpolitical-bias ${NONPOLITICAL_COLOR_SCHEME[bias]}`}>

--- a/src/pages/Popup/components/Report/Bias/Bias.scss
+++ b/src/pages/Popup/components/Report/Bias/Bias.scss
@@ -1,5 +1,6 @@
 .bias-content {
     margin-top: 30px;
+    font-size: 16px;
     .bias-boxes {
         display: flex;
         justify-content: center;

--- a/src/pages/Popup/components/Report/Bias/Bias.scss
+++ b/src/pages/Popup/components/Report/Bias/Bias.scss
@@ -1,0 +1,49 @@
+.bias-content {
+    margin-top: 30px;
+    .bias-boxes {
+        display: flex;
+        justify-content: center;
+        margin-bottom: 20px;
+        .bias-box {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 36px;
+            height: 36px;
+            border: solid black 2px;
+            margin: 0px 5px 0px 5px;
+            font-weight: 500;
+            font-size: 18px;
+        }
+
+        .left {
+            background-color: #1405bd;
+            border: solid #1405bd 2px;
+            color: white;
+        }
+
+        .left-center {
+            background-color: #599ddb;
+            border: solid #599ddb 2px;
+            color: white;
+        }
+
+        .center {
+            background-color: #c5c5c5;
+            border: solid #c5c5c5 2px;
+            color: white;
+        }
+
+        .right-center {
+            background-color: #e37c7c;
+            border: solid #e37c7c 2px;
+            color: white;
+        }
+
+        .right {
+            background-color: #de0100;
+            border: solid #de0100 2px;
+            color: white;
+        }
+    }
+}

--- a/src/pages/Popup/components/Report/Bias/Bias.scss
+++ b/src/pages/Popup/components/Report/Bias/Bias.scss
@@ -62,6 +62,10 @@
         background-color: #d2222d;
     }
 
+    .conspiracy-pseudo {
+        font-size: 14px;
+    }
+
     .questionable {
         background-color: #ffbf00;
     }

--- a/src/pages/Popup/components/Report/Bias/Bias.scss
+++ b/src/pages/Popup/components/Report/Bias/Bias.scss
@@ -46,4 +46,26 @@
             color: white;
         }
     }
+
+    .nonpolitical-bias {
+        margin: auto;
+        padding: 25px 0px 25px 0px;
+        width: 80%;
+        text-align: center;
+        text-transform: uppercase;
+        font-weight: 700;
+        font-size: 22px;
+        color: white;
+    }
+    .fake {
+        background-color: #d2222d;
+    }
+
+    .questionable {
+        background-color: #ffbf00;
+    }
+
+    .science {
+        background-color: #238823;
+    }
 }

--- a/src/pages/Popup/components/Report/Report.jsx
+++ b/src/pages/Popup/components/Report/Report.jsx
@@ -5,6 +5,7 @@ import { BounceLoader } from "react-spinners";
 import './Report.scss';
 
 import NoReport from '../NoReport/NoReport';
+import Bias from './Bias/Bias';
 
 const MBFC_API_URL = "http://mbfcapi.herokuapp.com/";
 const DEFAULT_REPORT = {
@@ -59,7 +60,7 @@ const Report = (props) => {
                                 </div>
                                 <div className="report-section">
                                     {reportSection === "BIAS" ? (
-                                        <h2>{report.bias}</h2>
+                                        <Bias bias={report.bias} />
                                     ) : (<></>)}
                                     {reportSection === "ACCURACY" ? (
                                         <h2>{report.accuracy}</h2>

--- a/src/pages/Popup/components/Report/Report.scss
+++ b/src/pages/Popup/components/Report/Report.scss
@@ -43,7 +43,7 @@
         }
 
         .report-section {
-            margin-top: 50px;
+            // margin-top: 50px;
         }
     }
 }


### PR DESCRIPTION
# Summary
Originally, I had put in a temporary design of just displaying the bias as text. This PR built a UI around that design by providing a chart-like display for political biases and large text with color indicators for extraneous biases returned. 

# Changes
- Added a L (left), L-C (left-center), C (center), R-C (right-center), R (right) chart to describe political biases
- Added an "Alert Box" to indicate whether a source was Satire, Questionable, Conspiracy, Conspiracy/Pseudoscience, Pro-science, or Fake.

# Screenshots
## Political Bias
![image](https://user-images.githubusercontent.com/66758185/103795006-0ee9d580-500b-11eb-83cc-01333dd46db3.png)

## Extraneous Bias
![image](https://user-images.githubusercontent.com/66758185/103795045-1c06c480-500b-11eb-8f1e-358017fdc80f.png)
